### PR TITLE
Laravel auto package discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,14 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "laravel": {
+      "providers": [
+        "Iyzico\\IyzipayLaravel\\IyzipayLaravelServiceProvider"
+      ],
+      "aliases": {
+        "IyzipayLaravel": "Iyzico\\IyzipayLaravel\\IyzipayLaravelFacade"
+      }
     }
   },
   "config": {


### PR DESCRIPTION
With Laravel 5.5, Laravel has an ability to discover packages  automatically. So, I added "laravel" key inside "extra" field with proper providers and aliases.